### PR TITLE
change archive_location to archive_url in exec.pp

### DIFF
--- a/manifests/install/exec.pp
+++ b/manifests/install/exec.pp
@@ -26,7 +26,7 @@ class vmwaretools::install::exec {
     timeout     => 0,
   }
 
-  if $vmwaretools::archive_location != 'puppet' {
+  if $vmwaretools::archive_url != 'puppet' {
     exec { 'download_vmwaretools':
       command => "${vmwaretools::working_dir}/download.sh",
       require => File["${vmwaretools::working_dir}/download.sh"],


### PR DESCRIPTION
Probably archive_url was named archive_location in the past ?. Changed to archive_url works for me (using Debian with VMwareTools-*.tar.gz directly in puppet module)
