### PR TITLE
Prefer curl over wget as wget is an optional package on most distro's

### DIFF
--- a/templates/download.sh.erb
+++ b/templates/download.sh.erb
@@ -14,11 +14,11 @@ DOWNLOAD_URL="<%= scope.lookupvar('vmwaretools::archive_url') %>/VMwareTools-<%=
 DOWNLOAD_LOCATION="<%= scope.lookupvar('vmwaretools::working_dir') %>/VMwareTools-<%= scope.lookupvar('vmwaretools::version') %>.tar.gz"
 GOOD_CHECKSUM="<%= scope.lookupvar('vmwaretools::archive_md5') %>"
 
-check_exec "/usr/bin/wget"
+check_exec "/usr/bin/curl"
 check_exec "/usr/bin/md5sum"
 check_exec "<%= scope.lookupvar('vmwaretools::params::awk_path') %>"
 
-/usr/bin/wget -q -O ${DOWNLOAD_LOCATION} ${DOWNLOAD_URL}
+/usr/bin/curl -s ${DOWNLOAD_URL} -o ${DOWNLOAD_LOCATION}
 chmod 600 ${DOWNLOAD_LOCATION}
 
 DOWNLOADED_CHECKSUM=$(/usr/bin/md5sum ${DOWNLOAD_LOCATION} | <%= scope.lookupvar('vmwaretools::params::awk_path') %> '{ print $1 }')


### PR DESCRIPTION
Download script: use curl instead of wget, on minimal rhel/centos installs wget is not available whereas curl is always present by default. It's safe to rely on curl being present.
