### PR TITLE
RedHat devel install: require the correct kernel headers for the running kernel and gcc to compile

### DIFF
--- a/manifests/install/package.pp
+++ b/manifests/install/package.pp
@@ -40,7 +40,7 @@ class vmwaretools::install::package {
 
     'RedHat' : {
       if $vmwaretools::redhat_install_devel == true {
-        package { 'kernel-devel':
+        package { [ "kernel-devel-${::kernelrelease}", 'gcc' ]:
           ensure => present,
         }
       }


### PR DESCRIPTION
'kernel-devel' install may install kernel headers of a later version than the currently installed kernel, thus make the version to be installed explicit.

On minimal installs, gcc isn't present either - so to compile the kernel modules this package would be required.
