### PR TITLE
Check for previous definition of commonly used build packages.

### DIFF
--- a/manifests/install/package.pp
+++ b/manifests/install/package.pp
@@ -42,15 +42,29 @@ class vmwaretools::install::package {
   case $::osfamily {
 
     'Debian' : {
-      package { ["linux-headers-${::kernelrelease}",'build-essential'] :
-        ensure => present,
+      if ! defined(Package['build-essential']) {
+        package{'build-essential':
+          ensure => installed,
+        }
+      }
+      if ! defined(Package["linux-headers-${::kernelrelease}"]) {
+        package{"linux-headers-${::kernelrelease}":
+          ensure => installed,
+        }
       }
     }
 
     'RedHat' : {
       if $vmwaretools::redhat_install_devel == true {
-        package { [ "kernel-devel-${::kernelrelease}", 'gcc' ]:
-          ensure => present,
+        if ! defined(Package["kernel-devel-${::kernelrelease}"]) {
+          package{"kernel-devel-${::kernelrelease}":
+            ensure => installed,
+          }
+        }
+        if ! defined(Package['gcc']) {
+          package{'gcc':
+            ensure => installed,
+          }
         }
       }
     }


### PR DESCRIPTION
This should address #10

Test that build packages have not been previously defined.
