### PR TITLE
Enhance 'kernel_upgrade' across supported OSes

### DIFF
--- a/manifests/kernel_upgrade.pp
+++ b/manifests/kernel_upgrade.pp
@@ -17,6 +17,21 @@
 #
 class vmwaretools::kernel_upgrade {
 
+  # The vmxnet3 driver isn't in the same place across every flavor of Linux,
+  # so we need to specify where that file is found across the distros.
+  case $osfamily {
+    /(?i-mx:debian)/: {
+      $vmxnet_driver = "/lib/modules/${::kernelrelease}/kernel/drivers/net/vmxnet3/vmxnet3.ko"
+    }
+    /(?i-mx:redhat)/: {
+      $vmxnet_driver = $::lsbmajdistrelease ? {
+        '5' => "/lib/modules/${::kernelrelease}/misc/vmxnet3.ko",
+        '6' => "/lib/modules/${::kernelrelease}/kernel/drivers/net/vmxnet3/vmxnet3.ko",
+      }
+    }
+    default: { fail("${::operatingsystem} is unsupported") }
+  }
+
   if $vmwaretools::params::deploy_files {
     Exec['vmware_config_tools'] {
       require => Exec['clean_vmwaretools'],
@@ -25,7 +40,7 @@ class vmwaretools::kernel_upgrade {
 
   exec { 'vmware_config_tools':
     command => '/usr/bin/vmware-config-tools.pl -d',
-    creates => "/lib/modules/${::kernelrelease}/kernel/drivers/scsi/vmw_pvscsi.ko",
+    creates => $vmxnet_driver,
   }
 
 }


### PR DESCRIPTION
<tt>kernel_upgrade</tt> currently searches for the driver <tt>"/lib/modules/${::kernelrelease}/kernel/drivers/scsi/vmw_pvscsi.ko"</tt>, which isn't reliable on RHEL/CentOS 5. I've added some conditional logic to search for <tt>vmxnet3.ko</tt> instead, which appears to be universally installed regardless of distro (albeit in different locations across the different versions of RHEL/CentOS).

This has been tested across the CentOS flavors mentioned but it probably needs at least a little bit more tire kicking on Ubuntu. I didn't have any clients handy tonight, so please merge with a grain of salt.
