### PR TITLE
vmwaretools_version.rb - check for Nil result before running sub

### DIFF
--- a/lib/facter/vmwaretools_version.rb
+++ b/lib/facter/vmwaretools_version.rb
@@ -7,7 +7,12 @@ Facter.add(:vmwaretools_version) do
   confine :virtual => :vmware
   setcode do
     if File::executable?("/usr/bin/vmware-toolbox-cmd")
-      Facter::Util::Resolution.exec("/usr/bin/vmware-toolbox-cmd -v").sub(%r{(\d*\.\d*\.\d*)\.\d*\s+\(build(-\d*)\)},'\1\2')
+      result = Facter::Util::Resolution.exec("/usr/bin/vmware-toolbox-cmd -v")
+      if result
+        result.sub(%r{(\d*\.\d*\.\d*)\.\d*\s+\(build(-\d*)\)},'\1\2')
+      else
+        "not installed"
+      end
     else
       "not installed"
     end


### PR DESCRIPTION
I was getting this error on some hosts related to the vmwaretools_version fact:

> Puppet (err): Could not run Puppet configuration client: Could not retrieve local facts: private method `sub' called for nil:NilClass

Updated the fact to check for a value before running .sub.  Otherwise, set to "not installed".

FYI @craigwatson:  this is unrelated to the issue I had posted last week re: virtual vs. physical.
