### PR TITLE
Correct assignment statement

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -56,7 +56,7 @@ class vmwaretools::params {
       default  => $vmwaretools::params::config_creates_default,
     }
   } else {
-    $config_creates_real == $vmwaretools::config_creates
+    $config_creates_real = $vmwaretools::config_creates
   }
 
   $awk_path = $::osfamily ? {


### PR DESCRIPTION
`puppet doc` was throwing the following error in my build environment:

```
Error: Could not generate documentation: Syntax error at '=='; expected '}' at /.../puppet/modules/vmwaretools/manifests/params.pp:59
```

This appears to just be a typo and the fix is simple
