### PR TITLE
Change purged to absent in package.pp

### DIFF
--- a/manifests/install/package.pp
+++ b/manifests/install/package.pp
@@ -23,7 +23,7 @@
 class vmwaretools::install::package {
 
   package { ['open-vm-tools','open-vm-dkms', 'vmware-tools-services']:
-    ensure => purged,
+    ensure => absent,
   }
 
   if !defined(Package['perl']) {


### PR DESCRIPTION
On CentOS / RedHat systems setting the package resource to ensure => purged causes the module to always report changes even after the packages have been uninstalled.. Setting the package to ensure => absent corrects this behavior on those systems. This is due to an open bug in puppet: https://tickets.puppetlabs.com/browse/PUP-1198
