### PR TITLE
Split out the package requirments for Debian and Ubuntu

### DIFF
--- a/manifests/install/package.pp
+++ b/manifests/install/package.pp
@@ -56,7 +56,7 @@ class vmwaretools::install::package {
             }
           }
         }
-        'Debain' : {
+        'Debian' : {
           if ! defined(Package["linux-headers-${::kernelrelease}"]) {
             package{"linux-headers-${::kernelrelease}":
               ensure => present,


### PR DESCRIPTION
You don't need the full build-essential to compile the modules, only the dependencies from gcc.  So in Debian just install in linux-headers-${::kernelrelease} as this package has a dependency on gcc (and the correct version of gcc to build for that kernel).

Leaving Ubuntu alone for now since I've not tested that.
