### PR TITLE
Try to work around the RHEL purged vs absent bug

### DIFF
--- a/manifests/install/package.pp
+++ b/manifests/install/package.pp
@@ -22,8 +22,15 @@
 #
 class vmwaretools::install::package {
 
-  package { $vmwaretools::params::purge_package_list:
-    ensure => purged,
+  if $::osfamily == 'RedHat' {
+    # Puppet's handling of 'purged' isn't consistent on RHEL/clones; use 'absent' instead
+    package { $vmwaretools::params::purge_package_list:
+      ensure => absent,
+    }
+  } else {
+    package { $vmwaretools::params::purge_package_list:
+      ensure => purged,
+    }
   }
 
   if !defined(Package['perl']) {


### PR DESCRIPTION
There's a bug/feature/something in Puppet that, on RHEL/clones, the package provider code for yum doesn't correctly handle 'purged'. When 'purged' is used, the package provider attempts to remove the package on every run. See [1] [2] [3] for discussion on this. I'm unsure how PuppetLabs plans on resolving it.

Example of the bug:

```
Oct  2 14:42:18 devtest-vmware puppet-agent[29873]: (/Stage[main]/Vmwaretools::Install::Package/Package[open-vm-tools-desktop]/ensure) created
Oct  2 14:42:19 devtest-vmware puppet-agent[29873]: (/Stage[main]/Vmwaretools::Install::Package/Package[vmware-tools-services]/ensure) created
Oct  2 14:42:20 devtest-vmware puppet-agent[29873]: (/Stage[main]/Vmwaretools::Install::Package/Package[open-vm-dkms]/ensure) created
Oct  2 14:42:20 devtest-vmware puppet-agent[29873]: (/Stage[main]/Vmwaretools::Install::Package/Package[open-vm-tools]/ensure) created
```

[1] https://projects.puppetlabs.com/issues/2833
[2] https://projects.puppetlabs.com/issues/11450
[3] https://tickets.puppetlabs.com/browse/PUP-1198
