### PR TITLE
removed duplicate 'open-vm-tools'

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -89,7 +89,7 @@ class vmwaretools::params {
   $purge_package_list = [ 'open-vm-tools', 'open-vm-dkms', 'vmware-tools-services',
                           'vmware-tools-foundation', 'open-vm-tools-desktop',
                           'open-vm-source', 'open-vm-toolbox', 'open-vm-tools-dbg',
-                          'open-vm-tools-gui', 'vmware-kmp-debug', 'vmware-kmp-default', 
+                          'open-vm-tools-gui', 'vmware-kmp-debug', 'vmware-kmp-default',
                           'vmware-kmp-pae', 'vmware-kmp-trace', 'vmware-guest-kmp-debug',
                           'vmware-guest-kmp-default', 'vmware-guest-kmp-desktop',
                           'vmware-guest-kmp-pae', 'libvmtools-devel', 'libvmtools0' ]

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -88,10 +88,9 @@ class vmwaretools::params {
 
   $purge_package_list = [ 'open-vm-tools', 'open-vm-dkms', 'vmware-tools-services',
                           'vmware-tools-foundation', 'open-vm-tools-desktop',
-                          'open-vm-source', 'open-vm-toolbox', 'open-vm-tools',
-                          'open-vm-tools-dbg', 'open-vm-tools-gui', 'vmware-kmp-debug',
-                          'vmware-kmp-default', 'vmware-kmp-pae', 'vmware-kmp-trace',
-                          'vmware-guest-kmp-debug', 'vmware-guest-kmp-default',
-                          'vmware-guest-kmp-desktop', 'vmware-guest-kmp-pae',
-                          'libvmtools-devel', 'libvmtools0' ]
+                          'open-vm-source', 'open-vm-toolbox', 'open-vm-tools-dbg',
+                          'open-vm-tools-gui', 'vmware-kmp-debug', 'vmware-kmp-default', 
+                          'vmware-kmp-pae', 'vmware-kmp-trace', 'vmware-guest-kmp-debug',
+                          'vmware-guest-kmp-default', 'vmware-guest-kmp-desktop',
+                          'vmware-guest-kmp-pae', 'libvmtools-devel', 'libvmtools0' ]
 }


### PR DESCRIPTION
Fixes error: 
Could not retrieve catalog from remote server: Error 400 on SERVER: Duplicate declaration: Package[open-vm-tools] is already declared in file /etc/puppet/environments/production/modules/vmwaretools/manifests/install/package.pp:27; cannot redeclare at /etc/puppet/environments/production/modules/vmwaretools/manifests/install/package.pp:27 on node foo.example.com