### PR TITLE
Set curl_proxy dafault to false

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -36,7 +36,7 @@
 # [*curl_proxy*]
 #   Specify an HTTP proxy to be used with curl when downloading the archive.
 #   This can be of the format http://<hostname>:<port>
-#   Default: undef (no proxy usage)
+#   Default: false (no proxy usage)
 #
 # [*fail_on_non_vmware*]
 #   Output a hard failure message if the module is run on non-vmware hardware.
@@ -129,7 +129,7 @@ class vmwaretools (
   $manage_dev_pkgs      = true,
   $manage_perl_pkgs     = true,
   $manage_curl_pkgs     = true,
-  $curl_proxy           = undef
+  $curl_proxy           = false
 ) {
 
   # Validate parameters where appropriate


### PR DESCRIPTION
After we moved from Passenger to Puppetserver, the ruby conditional in the download.sh.erb began evaluating to true with 'undef' leaving the script with command that looked like:

curl -s <url> -o <file> -x 

which would complain that -x required a parameter.