### PR TITLE
Adding BIOS address for 6.0 Update 2 (ver 3825889)

### DIFF
--- a/lib/facter/esx_version.rb
+++ b/lib/facter/esx_version.rb
@@ -34,6 +34,8 @@ Facter.add(:esx_version) do
               '5.5'
             when '0xE9A40'
               '6.0'
+            when '0xE99E0'
+              '6.0 update 2'
             else
               "unknown, please report #{bios_address}"
           end


### PR DESCRIPTION
BIOS Information
	Vendor: Phoenix Technologies LTD
	Version: 6.00
	Release Date: 09/21/2015
	Address: 0xE99E0
	Runtime Size: 91680 bytes
	ROM Size: 64 kB