### PR TITLE
Add logic to use different install command with tools version 10

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -58,7 +58,13 @@ class vmwaretools::params {
   }
 
   if $::vmwaretools::force_install == true {
-    $install_command = "echo 'yes' | ${::vmwaretools::working_dir}/vmware-tools-distrib/vmware-install.pl"
+    # The version 10 installer needs to use the -f (force) flag.
+    if ( versioncmp(vmwaretools::version,'10.0') >= 0 ) {
+      $install_command = "${vmwaretools::working_dir}/vmware-tools-distrib/vmware-install.pl -d -f"
+    }
+    else {
+      $install_command = "echo 'yes' | ${::vmwaretools::working_dir}/vmware-tools-distrib/vmware-install.pl"
+    }
   } else {
     $install_command = "${vmwaretools::working_dir}/vmware-tools-distrib/vmware-install.pl -d"
   }


### PR DESCRIPTION
The method of piping `echo 'yes'` into the installer does not work on
version 10 of the installer.  Instead, supply the '-f' flag to the
installer, which was added in 10 to force an install.